### PR TITLE
read templates in alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ See `invoice2data/templates` for existing templates. Just extend the list to add
 
 Templates are based on Yaml. They define one or more keywords to find the right template and regexp for fields to be extracted. They could also be a static value, like the full company name.
 
+Template files are tried in alphabetical order.
+
 We may extend them to feature options to be used during invoice processing.
 
 Example:

--- a/invoice2data/template.py
+++ b/invoice2data/template.py
@@ -1,5 +1,5 @@
 """
-This module abstracts templates for invoice providers. 
+This module abstracts templates for invoice providers.
 
 Templates are initially read from .yml files and then kept as class.
 """
@@ -33,7 +33,7 @@ def read_templates(folder):
     """
     output = []
     for path, subdirs, files in os.walk(folder):
-        for name in files:
+        for name in sorted(files):
             if name.endswith('.yml'):
                 tpl = ordered_load(open(os.path.join(path, name)).read())
                 tpl['template_name'] = name
@@ -43,7 +43,7 @@ def read_templates(folder):
                 required_fields = ['date', 'amount', 'invoice_number']
                 assert len(set(required_fields).intersection(tpl['fields'].keys())) == len(required_fields), \
                     'Missing required key in template {} {}. Found {}'.format(name, path, tpl['fields'].keys())
-                
+
                 # Keywords as list, if only one.
                 if type(tpl['keywords']) is not list:
                     tpl['keywords'] = [tpl['keywords']]
@@ -88,7 +88,7 @@ class InvoiceTemplate(OrderedDict):
             optimized_str = re.sub(' +', '', extracted_str)
         else:
             optimized_str = extracted_str
-        
+
         # Remove accents
         if self.options['remove_accents']:
             optimized_str = unidecode(optimized_str)


### PR DESCRIPTION
Try templates in alphabetic order. Previously, the entries were parsed
in arbitrary order which could lead to problems when more than one
template matches.

Reading the templates in alphabetical order is useful for defining a
"fallback" template that tries to extract information from unknown
invoices, while the specific templates can be used where necessary.