### PR TITLE
Differenciate com.scaleway.yml and net.online.yml

### DIFF
--- a/invoice2data/templates/com.scaleway.yml
+++ b/invoice2data/templates/com.scaleway.yml
@@ -5,6 +5,7 @@ fields:
   invoice_number: Invoice#(\d+)
 keywords:
 - FR35433115904
+- Invoice
 options:
   remove_whitespace: true
   currency: EUR


### PR DESCRIPTION
Currently, net.online.yml doesn't work because com.scaleway.yml matches Online.net invoices. This PR fixes this problem.