### PR TITLE
Do not use pytesseract

### DIFF
--- a/invoice2data/in_tesseract.py
+++ b/invoice2data/in_tesseract.py
@@ -1,35 +1,17 @@
 # -*- coding: utf-8 -*-
-# from wand.image import Image as WandImage
-from PIL import Image
-import pytesseract
-import os
 import subprocess
-import tempfile
 
 
 def to_text(path):
-    """Wraps Tesseract OCR. Not reliable at the moment."""
+    """Wraps Tesseract OCR."""
 
-    tiff_file = tempfile.NamedTemporaryFile(suffix='.tiff')
-    FNULL = open(os.devnull, 'w')
-    subprocess.call([
-        "convert",
-        "-density",
-        "350",
-        path,
-        "-depth",
-        "8",
-        tiff_file.name
-        ], stdout=FNULL, stderr=subprocess.STDOUT)
+    convert = "convert -density 350 %s -depth 8 tiff:-" % (path)
+    p1 = subprocess.Popen(convert.split(' '), stdout=subprocess.PIPE)
 
-    # TODO: find a way to do this in python?
-    # with WandImage(filename=path, resolution=200) as img:
-    #     img.compression_quality = 200
-    #     img.format='png'
-    #     img.save(filename=tempfile)
+    p2 = subprocess.Popen("tesseract stdin stdout".split(' '),
+                          stdin=p1.stdout, stdout=subprocess.PIPE)
+    out, err = p2.communicate()
 
-    extracted_str = pytesseract.image_to_string(Image.open(tiff_file))
-    tiff_file.close()
+    extracted_str = out.decode('utf-8')
+
     return extracted_str
-
-    # convert -density 300 file.pdf -depth 8 file.tiff


### PR DESCRIPTION
Hi,

It is "not reliable at the moment" because of PyTesseract, because it converts the tiff in bmp before passing it to tesseract, and a lot of quality is lost in the process. You don't need it. You can directly use the tesseract command in subprocess, which is simplifying the code a lot (you don't need a tempfile, you don't need Image, etc.).

It doesn't solve everything, because tesseract is not perfect, but I tested this patch on good scans and it is working a lot better than before.