### PR TITLE
Add more extensibility for the conditions that make a field a date

### DIFF
--- a/invoice2data/template.py
+++ b/invoice2data/template.py
@@ -27,9 +27,6 @@ OPTIONS_DEFAULT = {
     'line_separator': r'\n',
 }
 
-# add to this lambda if you want more fields parsed as date field
-is_date_field = lambda x: x.startswith('date') or x == 'requested_date'
-
 def read_templates(folder):
     """
     Load yaml templates from template folder. Return list of dicts.
@@ -181,7 +178,7 @@ class InvoiceTemplate(OrderedDict):
                     res_find = re.findall(v, optimized_str)
                 if res_find:
                     logger.debug("res_find=%s", res_find)
-                    if is_date_field(k):
+                    if k.startswith('date') or k.endswith('date'):
                         output[k] = self.parse_date(res_find[0])
                         if not output[k]:
                             logger.error(

--- a/invoice2data/template.py
+++ b/invoice2data/template.py
@@ -27,6 +27,9 @@ OPTIONS_DEFAULT = {
     'line_separator': r'\n',
 }
 
+# add to this lambda if you want more fields parsed as date field
+is_date_field = lambda x: x.startswith('date') or x == 'requested_date'
+
 def read_templates(folder):
     """
     Load yaml templates from template folder. Return list of dicts.
@@ -178,7 +181,7 @@ class InvoiceTemplate(OrderedDict):
                     res_find = re.findall(v, optimized_str)
                 if res_find:
                     logger.debug("res_find=%s", res_find)
-                    if k.startswith('date'):
+                    if is_date_field(k):
                         output[k] = self.parse_date(res_find[0])
                         if not output[k]:
                             logger.error(


### PR DESCRIPTION
Currently a date field is identified if starts with "date" . I extend this a little bit with a lambda function because i also need requested_date in my  templates to be evaled like a date.
This looks like a nice way to extend that depending on one's needs for date fields