### PR TITLE
Skip empty sublines

### DIFF
--- a/invoice2data/template.py
+++ b/invoice2data/template.py
@@ -213,7 +213,7 @@ class InvoiceTemplate(OrderedDict):
             self['lines']['first_line'] = self['lines']['line']
         for line in re.split(self.options['line_separator'], content):
             # if the line has empty lines in it , skip them
-            if  re.search(r'''^\s*\n$''', line) or not line:
+            if not line.strip('').strip('\n') or not line:
                 continue
             if 'first_line' in self['lines']:
                 match = re.search(self['lines']['first_line'], line)

--- a/invoice2data/template.py
+++ b/invoice2data/template.py
@@ -212,6 +212,9 @@ class InvoiceTemplate(OrderedDict):
                 'last_line' not in self['lines']:
             self['lines']['first_line'] = self['lines']['line']
         for line in re.split(self.options['line_separator'], content):
+            # if the line has empty lines in it , skip them
+            if  re.search(r'''^\s*\n$''', line) or not line:
+                continue
             if 'first_line' in self['lines']:
                 match = re.search(self['lines']['first_line'], line)
                 if match:


### PR DESCRIPTION
Found a template with empty sub-lines in the line itself. this fixes that.

e.g.

      "Line that corresponds to the template first_line"
            \s\s\s\s\\n
      "Line that corresponds to the template line"
          \s\\s\s\s\\n
      " another line that corresponds to the template line"