### PR TITLE
replaced raw_date with res_find[0] in template.py file

### DIFF
--- a/invoice2data/template.py
+++ b/invoice2data/template.py
@@ -182,7 +182,7 @@ class InvoiceTemplate(OrderedDict):
                         output[k] = self.parse_date(res_find[0])
                         if not output[k]:
                             logger.error(
-                                "Date parsing failed on date '%s'", raw_date)
+                                "Date parsing failed on date '%s'", res_find[0])
                             return None
                     elif k.startswith('amount'):
                         output[k] = self.parse_number(res_find[0])


### PR DESCRIPTION
raw_date is not defined anywhere in the template.py file. Date parsing fails for res_find[0], Hence error logger must show res_find[0]. 
-Tested on My own Template.
@dpocock