### PR TITLE
Command line argument added for choosing output csv file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.69
+current_version = 0.2.70
 commit = True
 tag = True
 message = Bump version {current_version} > {new_version} [skip ci]

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -28,7 +28,7 @@ options:
 
 Let's look at each field:
 
-- `issuer`: The name of the invoice issuer. Can the company name and country.
+- `issuer`: The name of the invoice issuer. Can have the company name and country.
 - `keywords`: Also a required field. These are used to pick the correct template. Be as specific as possible. As we add more templates, we need to avoid duplicate matches. Using the VAT number, email, website, phone, etc are generally good choices. ALL keywords need to match to use the template.
 
 ### Fields

--- a/invoice2data/template.py
+++ b/invoice2data/template.py
@@ -182,7 +182,7 @@ class InvoiceTemplate(OrderedDict):
                         output[k] = self.parse_date(res_find[0])
                         if not output[k]:
                             logger.error(
-                                "Date parsing failed on date '%s'", raw_date)
+                                "Date parsing failed on date '%s'", res_find[0])
                             return None
                     elif k.startswith('amount'):
                         output[k] = self.parse_number(res_find[0])

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 setup(
     name='invoice2data',
-    version='0.2.69',
+    version='0.2.70',
     author='Manuel Riel',
     author_email='github@snapdragon.cc',
     url='https://github.com/m3nu/invoice2data',


### PR DESCRIPTION
@m3nu Need suggestions regarding the changes I made, you can edit/change accordingly.
I have added the command line argument for choosing output csv file, using -o or --output. If no arguments given, writes to 'invoices-output.csv' by default.
