### PR TITLE
Command line argument added for choosing output csv file

### DIFF
--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -61,6 +61,9 @@ def main():
     
     parser.add_argument('input_files', type=argparse.FileType('r'), nargs='+',
                         help='File or directory to analyze.')
+    
+    parser.add_argument('--output', '-o', 
+                        help="output CSV file.")
 
     args = parser.parse_args()
 
@@ -90,7 +93,10 @@ def main():
                     date=res['date'].strftime('%Y-%m-%d'),
                     desc=res['desc'])
                 shutil.copyfile(f.name, join(args.copy, filename))
-    invoices_to_csv(output, 'invoices-output.csv')
+    if args.output:
+        invoices_to_csv(output, args.output)
+    else:
+        invoices_to_csv(output, 'invoices-output.csv')
 
 if __name__ == '__main__':
     main()

--- a/invoice2data/template.py
+++ b/invoice2data/template.py
@@ -182,7 +182,7 @@ class InvoiceTemplate(OrderedDict):
                         output[k] = self.parse_date(res_find[0])
                         if not output[k]:
                             logger.error(
-                                "Date parsing failed on date '%s'", raw_date)
+                                "Date parsing failed on date '%s'", res_find[0])
                             return None
                     elif k.startswith('amount'):
                         output[k] = self.parse_number(res_find[0])


### PR DESCRIPTION
@m3nu  Need suggestions regarding the changes I made, you can edit/change accordingly.
I have added the command line argument for choosing output csv file, using -o or --output. If no arguments given, writes to 'invoices-output.csv' by default.