### PR TITLE
Command line argument added for choosing output csv file

### DIFF
--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -62,7 +62,7 @@ def main():
     parser.add_argument('input_files', type=argparse.FileType('r'), nargs='+',
                         help='File or directory to analyze.')
     
-    parser.add_argument('--output', '-o', 
+    parser.add_argument('--output', '-o', dest='output_csv', default='invoices-output.csv',
                         help="output CSV file.")
 
     args = parser.parse_args()
@@ -93,10 +93,9 @@ def main():
                     date=res['date'].strftime('%Y-%m-%d'),
                     desc=res['desc'])
                 shutil.copyfile(f.name, join(args.copy, filename))
-    if args.output:
-        invoices_to_csv(output, args.output)
-    else:
-        invoices_to_csv(output, 'invoices-output.csv')
+    if args.output_csv[-4:]!='.csv':
+        args.output_csv += '.csv'
+    invoices_to_csv(output, args.output_csv)
 
 if __name__ == '__main__':
     main()

--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -61,6 +61,9 @@ def main():
     
     parser.add_argument('input_files', type=argparse.FileType('r'), nargs='+',
                         help='File or directory to analyze.')
+    
+    parser.add_argument('--output', '-o', 
+                        help="output CSV file.")
 
     args = parser.parse_args()
 
@@ -90,7 +93,10 @@ def main():
                     date=res['date'].strftime('%Y-%m-%d'),
                     desc=res['desc'])
                 shutil.copyfile(f.name, join(args.copy, filename))
-    invoices_to_csv(output, 'invoices-output.csv')
+    if args.output:
+        invoices_to_csv(output, args.output)
+    else:
+        invoices_to_csv(output, 'invoices-output.csv')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
@m3nu  @dpocock Need suggestions regarding the changes I made, you can edit/change accordingly.
I have added the command line argument for choosing output csv file, using -o or --output options. If no such argument given, writes to 'invoices-output.csv' by default.
