### PR TITLE
Add optional csv naming feature

### DIFF
--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -62,6 +62,9 @@ def main():
     parser.add_argument('input_files', type=argparse.FileType('r'), nargs='+',
                         help='File or directory to analyze.')
 
+    parser.add_argument('--csv-name', '-n', dest='change_csv_name',
+                        help='Custom name for csv to be saved.')
+
     args = parser.parse_args()
 
     if args.debug:
@@ -90,7 +93,14 @@ def main():
                     date=res['date'].strftime('%Y-%m-%d'),
                     desc=res['desc'])
                 shutil.copyfile(f.name, join(args.copy, filename))
-    invoices_to_csv(output, 'invoices-output.csv')
+    if '.csv' not in args.change_csv_name:
+        args.change_csv_name = args.change_csv_name + '.csv'
+
+    if args.change_csv_name:
+        invoices_to_csv(output, args.change_csv_name)
+    else:
+        invoices_to_csv(output, 'invoices-output.csv')
+
 
 if __name__ == '__main__':
     main()

--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -62,7 +62,7 @@ def main():
     parser.add_argument('input_files', type=argparse.FileType('r'), nargs='+',
                         help='File or directory to analyze.')
 
-    parser.add_argument('--csv-name', '-n', dest='change_csv_name',
+    parser.add_argument('--csv-name', '-n', dest='change_csv_name', default='invoices-output.csv',
                         help='Custom name for csv to be saved.')
 
     args = parser.parse_args()
@@ -96,11 +96,7 @@ def main():
     if args.change_csv_name:
         if '.csv' not in args.change_csv_name:
             args.change_csv_name = args.change_csv_name + '.csv'
-
-    if args.change_csv_name:
-        invoices_to_csv(output, args.change_csv_name)
-    else:
-        invoices_to_csv(output, 'invoices-output.csv')
+        invoices_to_csv(output, args.change_csv_name)    
 
 
 if __name__ == '__main__':

--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -93,8 +93,9 @@ def main():
                     date=res['date'].strftime('%Y-%m-%d'),
                     desc=res['desc'])
                 shutil.copyfile(f.name, join(args.copy, filename))
-    if '.csv' not in args.change_csv_name:
-        args.change_csv_name = args.change_csv_name + '.csv'
+    if args.change_csv_name:
+        if '.csv' not in args.change_csv_name:
+            args.change_csv_name = args.change_csv_name + '.csv'
 
     if args.change_csv_name:
         invoices_to_csv(output, args.change_csv_name)


### PR DESCRIPTION
using `--csv-name` or `-n` the user can change the default name.
Example:
`invoice2data -n invoice_csv inv.pdf` saves the csv as `invoice_csv.csv`
@dpocock