### PR TITLE
Fixes to main positional argument

### DIFF
--- a/invoice2data/main.py
+++ b/invoice2data/main.py
@@ -88,8 +88,12 @@ def create_parser():
 
     return parser
 
-def main(args):
+def main(args=''):
     '''Take folder or single file and analyze each.'''
+    
+    if not args:
+        parser = create_parser()
+        args = parser.parse_args()
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
Upon typing `invoice2data invoice.pdf` I was facing the issue: 
```
TypeError: main() missing 1 required positional argument: 'args'
```
I have fixed those. 
@dpocock
